### PR TITLE
Fix deprecation warning (util.confit -> confuse)

### DIFF
--- a/beetsplug/yearfixer/__init__.py
+++ b/beetsplug/yearfixer/__init__.py
@@ -7,7 +7,7 @@
 import os
 
 from beets.plugins import BeetsPlugin
-from beets.util.confit import ConfigSource, load_yaml
+from confuse import ConfigSource, load_yaml
 
 from beetsplug.yearfixer.command import YearFixerCommand
 

--- a/beetsplug/yearfixer/command.py
+++ b/beetsplug/yearfixer/command.py
@@ -12,7 +12,7 @@ from beets.dbcore.query import NumericQuery, MatchQuery, AndQuery, OrQuery, \
     NoneQuery
 from beets.library import Library, Item, parse_query_parts
 from beets.ui import Subcommand, decargs
-from beets.util.confit import Subview
+from confuse import Subview
 from beetsplug.yearfixer import common
 
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -28,7 +28,7 @@ from beets.util import (
     bytestring_path,
     displayable_path,
 )
-from beets.util.confit import Subview, Dumper
+from confuse import Subview, Dumper
 from six import StringIO
 
 from beetsplug import yearfixer


### PR DESCRIPTION
Fixes #4

Replace all occurences of util.confit imports with imports of the
external confuse library newly introduced in beets 1.5.0.